### PR TITLE
A even number of cores should always be offered to make

### DIFF
--- a/sisyphus.pl
+++ b/sisyphus.pl
@@ -94,7 +94,7 @@ my $wait = 1;
 my $force = 0;
 our $debug = 0;
 my $threads = `cat /proc/cpuinfo |grep "^processor"|wc -l`;
-$threads = ($threads == 1) ?  1 :  $threads/2;
+$threads = ($threads == 1) ?  1 :  int($threads/2);
 
 my ($help,$man) = (0,0);
 


### PR DESCRIPTION
If Sisyphus is run on a system with just one core it will fail, since it will offer 0.5 cores to make. We cant' have that now, can we? :p
