### PR TITLE
Fix miseq prints + no unidentified bug

### DIFF
--- a/generateReport.pl
+++ b/generateReport.pl
@@ -365,11 +365,15 @@ $metaData{SisyphusVersion} = $sisyphus->version();
 $metaData{CsVersion} = $sisyphus->getCSversion();
 $metaData{InstrumentModel} = $sisyphus->machineType();
 $metaData{RtaVersion} = $sisyphus->getRTAversion();
-$metaData{FlowCellVer} = $sisyphus->getFlowCellVersion();
 $metaData{FlowCellId} = $sisyphus->fcId();
-$metaData{SBSversion} = $sisyphus->getSBSversion();
 $metaData{ClusterKitVersion} = $sisyphus->getClusterKitVersion();
 $metaData{Qoffset} = $offset;
+# metaData information only available for HiSeq
+if($sisyphus->machineType() ne 'miseq'){
+   $metaData{FlowCellVer} = $sisyphus->getFlowCellVersion();
+   $metaData{SBSversion} = $sisyphus->getSBSversion();
+}
+
 my $runInfo = $sisyphus->getRunInfo();
 for(my $i=0; $i<@{$runInfo->{reads}}; $i++){
     my $read = $runInfo->{reads}->[$i];

--- a/quickReport.pl
+++ b/quickReport.pl
@@ -197,7 +197,7 @@ foreach my $lane (sort {$a<=>$b} keys %{$RtaLaneStats}){
 	printf $repFh sprintf('%.1f±%.1f', $result->{"t"}->{MEAN},$result->{'t'}->{STDV});
 	print $repFh "\t", join(',', @fractionSorted);
 
-	print $repFh "\t", (defined($laneUnknown{$lane}) ? $laneUnknown{$lane} : '');
+	print $repFh "\t", (defined($laneUnknown{$lane}) ? $laneUnknown{$lane} : 0);
 
 	print $repFh "\n";
     }

--- a/sisyphus.pl
+++ b/sisyphus.pl
@@ -228,14 +228,19 @@ $rPath =~ s:/*$::;
 $oPath =~ s:/*$::;
 $aPath =~ s:/*$::;
 $sPath =~ s:/*$::;
-$anPath =~ s:/*$::;
+if($miseq){
+    $anPath =~ s:/*$::;
+}
 
 # Set combined paths
 my $targetPath = "$rHost:$rPath";
 my $summaryPath = "$sHost:$sPath";
 my $archivePath = "$aHost:$aPath";
 my $rBin = "$rPath/$rfName/Sisyphus";
-my $analysisPath = "$anPath/$rfName";
+my $analysisPath = undef;
+if($miseq){
+    my $analysisPath = "$anPath/$rfName";
+}
 
 if($debug){
     print "\$rHost => $rHost\n";


### PR DESCRIPTION
**Fixed issues concerning #62:**
There are no longer any prints about uninitialized values. This was solved by adding some simple if-statements. It is possible that it can be solved in a more elegant way, but it works!

**Also fixed #57:**
The problem was solved by printing a zero instead of nothing in the quickreport in cases where there are no unidentified reads. 