### PR TITLE
QCvalidate syntax fix

### DIFF
--- a/lib/Molmed/Sisyphus/QCRequirementValidation.pm
+++ b/lib/Molmed/Sisyphus/QCRequirementValidation.pm
@@ -419,7 +419,7 @@ sub checkUnidentified {
 		if(exists($warningReq->{'unidentified'})) {	
 			$warnings->{unidentified}->{'req'} = $warningReq->{'unidentified'}
 		} else {
-			$warnings->{unidentified}->{'req'} = $qcRequirements->{'unidentified'};
+			$warnings->{unidentified}->{'req'} = $qcRequirements->{warning}->{'unidentified'};
 		}
                 $warnings->{unidentified}->{'res'} = $result->[$resultMapping->{'Unidentified'}];
 		print "Failed unidentified warning requirement: $warnings->{unidentified}->{'res'} ($warnings->{unidentified}->{'req'})!\n" if($self->{VERBOSE});

--- a/qcValidateRun.pl
+++ b/qcValidateRun.pl
@@ -210,5 +210,10 @@ if(defined $mail && $mail =~ m/\w\@\w/){
 	}
 }
 
-exit 1;
+
+if(defined($result)){
+	exit 1;
+}
+
+exit 0;
 


### PR DESCRIPTION
Fixed small bugs in QC validation. Now QC won't fail if there are only warnings and the warning thresholds will be written correctly in the warning report. 