### PR TITLE
Quickreport can now be written for HiSeqX lanes with multiple samples

### DIFF
--- a/lib/Molmed/Sisyphus/Common.pm
+++ b/lib/Molmed/Sisyphus/Common.pm
@@ -1361,30 +1361,22 @@ sub readSampleSheet{
                     my @r = split /,/, $dataRow;
                     $r[$columnMap->{'index'}] = 'unknown' if($r[$columnMap->{'index'}] !~ m/^[ACGT-]+$/); # Use 'unknown' for unspecified index tags
                     unless($r[6] =~ m/^y/i){ # Skip the controls
-                    # Use project + lane + index tag    as keys
-                    if(defined($sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_Name'}]})) {
-                        #Calculate sample number
-                        if(!defined($sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_ID'}]})) {
-                            $sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_Name'}]}->{'counter'} =
-                                $sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_Name'}]}->{'counter'} + 1;
-                            $sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_ID'}]} =
-                                $sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_Name'}]}->{'counter'};
-                            } else {
-                                die "Unhandled case!!!\n";
-                            }
-                        } else {
-			    #Sample name haven't been seen before
-                            $sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_Name'}]}->{'counter'} = $r[$columnMap->{'index'}] eq 'unknown' ? 0 : 1;
-                            $sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_ID'}]} = $r[$columnMap->{'index'}] eq 'unknown' ? 0 : 1;
+                        
+			if(defined($sampleCounter->{$r[$columnMap->{'Lane'}]})){
+                                $sampleCounter->{$r[$columnMap->{'Lane'}]}++;
                         }
-                        #Save information in hash
+                        else{
+                                 $sampleCounter->{$r[$columnMap->{'Lane'}]} = 1;
+                        }
+
+			#Save information in hash
                         $sampleSheet{$r[$columnMap->{'Sample_Project'}]}->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'index'}]} =
                             {'SampleID'=>$r[$columnMap->{'Sample_ID'}],
                              'SampleName'=>$r[$columnMap->{'Sample_Name'}],
                              'Index'=>$r[$columnMap->{'index'}],
                              'Description'=>$r[$columnMap->{'Description'}],
                              'SampleWell'=>$r[$columnMap->{'Sample_Well'}],
-                             'SampleNumber'=>$sampleCounter->{$r[$columnMap->{'Lane'}]}->{$r[$columnMap->{'Sample_ID'}]},
+                             'SampleNumber'=>$sampleCounter->{$r[$columnMap->{'Lane'}]},
                              'SamplePlate'=>$r[$columnMap->{'Sample_Plate'}],
                              'Lane'=>$r[$columnMap->{'Lane'}],
                              'SampleProject'=>$r[$columnMap->{'Sample_Project'}],

--- a/sisyphus_qc.xml
+++ b/sisyphus_qc.xml
@@ -13,10 +13,18 @@
 				<numberOfCluster>140</numberOfCluster>
 				<overridePoolingRequirement>0</overridePoolingRequirement>
 				<lengths>
+					<l100>
+						<q30>11</q30>
+						<errorRate>2.0</errorRate>
+					</l100>
 					<l101>
 						<q30>11</q30>
 						<errorRate>2.0</errorRate>
 					</l101>
+					<l50>
+						<q30>5.6</q30>
+						<errorRate>1.0</errorRate>
+					</l50>
 					<l51>
 						<q30>5.6</q30>
 						<errorRate>1.0</errorRate>
@@ -41,18 +49,30 @@
 						<q30>18</q30>
 						<errorRate>2.0</errorRate>
 					</l125>
-   					 <l126>
+   					<l126>
                                                 <q30>18</q30>
                                                 <errorRate>2.0</errorRate>
                                         </l126>
 					<l100>
 						<q30>14</q30>
 						<errorRate>2.0</errorRate>
-					</l100>
+					</l100>	
+					<l101>
+						<q30>14</q30>
+						<errorRate>2.0</errorRate>
+					</l101>
 					<l50>
 						<q30>7.0</q30>
 						<errorRate>1.0</errorRate>
 					</l50>
+					<l51>
+						<q30>7.0</q30>
+						<errorRate>1.5</errorRate>
+					</l51>
+					<l62>
+						<q30>7.0</q30>
+						<errorRate>1.5</errorRate>
+					</l62>
 				</lengths>
 			</warning>
 		</platform>
@@ -84,10 +104,42 @@
 			<lengths>
 			</lengths>
 			<warning>
-				<unidentified>5.0</unidentified>
+				<unidentified>10.0</unidentified>
 				<numberOfCluster>110</numberOfCluster>
 				<overridePoolingRequirement>0</overridePoolingRequirement>
-				<lengths>
+				<lengths>	
+					<l151>
+						<q30>12.3</q30>
+						<errorRate>2.0</errorRate>
+					</l151>
+					<l101>
+						<q30>8.8</q30>
+						<errorRate>2.0</errorRate>
+					</l101>
+				</lengths>
+			</warning>
+		</platform>
+		<platform>
+			<controlSoftware>HiSeq Control Software</controlSoftware>
+			<version>HiSeq Rapid Flow Cell v2</version>
+			<mode>RapidRun</mode>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>10.0</unidentified>
+				<numberOfCluster>110</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>	
+					<l251>
+						<q30>18.7</q30>
+						<errorRate>5.0</errorRate>
+					</l251>
+					<l250>
+						<q30>18.7</q30>
+						<errorRate>5.0</errorRate>
+					</l250>
 					<l151>
 						<q30>12.3</q30>
 						<errorRate>2.0</errorRate>
@@ -107,17 +159,17 @@
 			<lengths>
 			</lengths>
 			<warning>
-				<unidentified>5.0</unidentified>
+				<unidentified>10.0</unidentified>
 				<numberOfCluster>10</numberOfCluster>
 				<overridePoolingRequirement>0</overridePoolingRequirement>
 				<lengths>
 					<l251>
 						<q30>1.8</q30>
-						<errorRate>2.0</errorRate>
+						<errorRate>5.0</errorRate>
 					</l251>
 					<l151>
 						<q30>1.1</q30>
-						<errorRate>1.5</errorRate>
+						<errorRate>2.0</errorRate>
 					</l151>
 					<l26>
 						<q30>0.2</q30>
@@ -134,13 +186,13 @@
 			<lengths>
 			</lengths>
 			<warning>
-				<unidentified>5.0</unidentified>
+				<unidentified>10.0</unidentified>
 				<numberOfCluster>18</numberOfCluster>
 				<overridePoolingRequirement>0</overridePoolingRequirement>
 				<lengths>
 					<l301>
 						<q30>3.7</q30>
-						<errorRate>2.5</errorRate>
+						<errorRate>5.0</errorRate>
 					</l301>
 					<l75>
 						<q30>1.1</q30>


### PR DESCRIPTION
- Fixed HiSeqX bug where incorrect sample numbers were used, which lead to that some fastq files could not be found.

- Updated the QC-critera according to the new guidelines.