### PR TITLE
Auto-start ngi_pipeline with ssh and curl

### DIFF
--- a/sisyphus.yml
+++ b/sisyphus.yml
@@ -45,6 +45,9 @@ OUTBOX_PATH: DEFAULT
 # The host path to where data that should be processed with NGI-pipeline will be delivered.
 NGI_HOST: nestor.uppmax.uu.se
 
+# The port on which the ngi pipeline will respond on the remote host.
+NGI_PORT: 6666
+
 # The host path where NGI-pipeline data should be delivered.
 NGI_REMOTE_PATH: /proj/a2014205/archive/
 


### PR DESCRIPTION
This is just an untested quick hack - but I wanted the opinion of you guys if you think that this is a viable way to auto-start the `ngi_pipeline` for now. I'm thinking that this could be a fast solution that we could use now until we have Hercules fully operational. It has the benefit that it will work also with starting Sisyphus manually - which we would miss if we incorporated it into to Hercules right now.