### PR TITLE
Pica fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - "cpanm --quiet --notest Digest::MD5"
   - "cpanm --quiet --notest XML::Simple"
   - "cpanm --quiet --notest Archive::Zip"
-  - "cpanm --quiet --notest PDL"
+  - "cpanm --quiet --notest CHM/PDL-2.007.tar.gz"
   - "cpanm --quite --notest XML::LibXSLT"
   - echo 'our $VERSION="'`perl ./version.pl`'"' |tee VERSION
   - find . > MANIFEST

--- a/aeacus-reports.pl
+++ b/aeacus-reports.pl
@@ -215,6 +215,7 @@ my $repJob =
                                            TIME=>"0-10:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
                                            QOS=>$uQos,            # High priority
                                            PARTITION=>'core',     # core or node (or devel));
+                                           CORES=>'2',
                                            MAIL_USER=>$email,
                                            MAIL_TYPE=>'FAIL'
                                           );

--- a/sisyphus.yml
+++ b/sisyphus.yml
@@ -65,14 +65,14 @@ ARCHIVE_HOST: milou-b.uppmax.uu.se
 # Default to nobackup dir as this will only be used while
 # staging the data for transfer to Swestore
 # This way we can hardlink instead of copy fastq-files
-ARCHIVE_PATH: /gulo/proj_nobackup/a2009002/private/archive-tmp
+ARCHIVE_PATH: /proj/a2009002/private/nobackup/archive-tmp
 
 # The iRODS path to SweStore archive
 SWESTORE_PATH: /ssUppnexZone/proj/a2009002
 
 # Root dir of temporary directory to use
 # (eg when verifying the archive copies)
-TEMP_PATH: /gulo/proj_nobackup/a2009002/private/tmp
+TEMP_PATH: /proj/a2009002/private/nobackup/tmp
 
 # The host on which to put the summaries
 SUMMARY_HOST: mm-xlas002

--- a/sisyphus_qc.xml
+++ b/sisyphus_qc.xml
@@ -41,7 +41,7 @@
 			<lengths>
 			</lengths>
 			<warning>
-				<unidentified>5.0</unidentified>
+				<unidentified>10.0</unidentified>
 				<numberOfCluster>180</numberOfCluster>
 				<overridePoolingRequirement>0</overridePoolingRequirement>
 				<lengths>
@@ -50,9 +50,9 @@
 						<errorRate>2.0</errorRate>
 					</l125>
    					<l126>
-                                                <q30>18</q30>
-                                                <errorRate>2.0</errorRate>
-                                        </l126>
+                         <q30>18</q30>
+                        <errorRate>2.0</errorRate>
+                    </l126>
 					<l100>
 						<q30>14</q30>
 						<errorRate>2.0</errorRate>


### PR DESCRIPTION
Minor changes

- Paths in config file do not longer point directly to gulo.

- 2 cores are now allocated to Report jobs at Uppmax. 1 core is not enough for HiSeqX runs (and some "regular" HiSeqs).

- Updated qc-critera to match the official document in canea. 