### PR TITLE
Faster fastq search

### DIFF
--- a/lib/Molmed/Sisyphus/Common.pm
+++ b/lib/Molmed/Sisyphus/Common.pm
@@ -1433,7 +1433,9 @@ sub readSampleSheet{
                     if(defined($columnMap->{'index2'}) && length($r[$columnMap->{'index2'}]) > 0 && length($r[$columnMap->{'index'}]) > 0) {
                         $index .= "-" . $r[$columnMap->{'index2'}];
 		            }
-                    
+                    elsif(length($r[$columnMap->{'index'}]) < 0 && length($r[$columnMap->{'index2'}]) > 0){
+                        $index = $r[$columnMap->{'index2'}];
+                    }
 
                     # Save information to hash
                     $sampleSheet{$r[$columnMap->{'Sample_Project'}]}->{defined($columnMap->{'Lane'}) ? $r[$columnMap->{'Lane'}] : 1}->{$index} =

--- a/lib/Molmed/Sisyphus/Common.pm
+++ b/lib/Molmed/Sisyphus/Common.pm
@@ -3063,8 +3063,10 @@ sub machineType{
 sub getMachineID {
     my $self = shift;
     if(!defined $self->{RUNPARAMS}){
-        confess "RunParameters haven't been loaded\n";
-    } elsif(defined($self->{RUNPARAMS}->{ScannerID})){
+        # Load runParameters
+        $self->runParameters();
+    } 
+    if(defined($self->{RUNPARAMS}->{ScannerID})){
         return $self->{RUNPARAMS}->{ScannerID};
     } elsif(defined($self->{RUNPARAMS}->{Setup}->{ScannerID})) {
         return $self->{RUNPARAMS}->{Setup}->{ScannerID};

--- a/lib/Molmed/Sisyphus/Common.pm
+++ b/lib/Molmed/Sisyphus/Common.pm
@@ -1421,7 +1421,7 @@ sub readSampleSheet{
                 chomp($dataRow);
                 $dataRow=~ s/[\012\015]*$//;
                 my @r = split /,/, $dataRow;
-                $r[$columnMap->{'index'}] = 'unknown' if($r[$columnMap->{'index'}] !~ m/^[ACGT-]+$/); # Use 'unknown' for unspecified index tags
+                $r[$columnMap->{'index'}] = 'unknown' if($r[$columnMap->{'index'}] !~ m/^[ACGT-]+$/ && $r[$columnMap->{'index2'}] !~ m/^[ACGT-]+$/); # Use 'unknown' for unspecified index tags
                 unless($r[6] =~ m/^y/i){ # Skip the controls
                       
                     if(!defined($sampleCounterHash->{$r[$columnMap->{'Sample_Name'}]})){
@@ -1429,11 +1429,13 @@ sub readSampleSheet{
                         $sampleCounterHash->{$r[$columnMap->{'Sample_Name'}]} = $sampleCounter;
                     }
 
-		    #Save information in hash
                     my $index = $r[$columnMap->{'index'}];
-                    if(defined($columnMap->{'index2'}) && defined($r[$columnMap->{'index2'}])) {
+                    if(defined($columnMap->{'index2'}) && length($r[$columnMap->{'index2'}]) > 0 && length($r[$columnMap->{'index'}]) > 0) {
                         $index .= "-" . $r[$columnMap->{'index2'}];
-		    }
+		            }
+                    
+
+                    # Save information to hash
                     $sampleSheet{$r[$columnMap->{'Sample_Project'}]}->{defined($columnMap->{'Lane'}) ? $r[$columnMap->{'Lane'}] : 1}->{$index} =
                         {'SampleID'=>$r[$columnMap->{'Sample_ID'}],
                          'SampleName'=>$r[$columnMap->{'Sample_Name'}],

--- a/quickReport.pl
+++ b/quickReport.pl
@@ -130,7 +130,7 @@ sub findFastq{
     }
 }
 use File::Find;
-find({wanted => sub{findFastq(\%files)}, no_chdir => 1, follow => 1}, $rfPath);
+find({wanted => sub{findFastq(\%files)}, no_chdir => 1, follow => 1}, "$rfPath/Unaligned");
 
 my $laneQC;
 my $samples;

--- a/sisyphus.yml
+++ b/sisyphus.yml
@@ -106,7 +106,7 @@ TEMP_PATH: /proj/a2009002/private/nobackup/tmp
 SUMMARY_HOST: mm-xlas002
 
 # The directory on ARCHIVE_HOST to put the runfolder in
-SUMMARY_PATH: /mnt/Seq-Summaries/2015/
+SUMMARY_PATH: /mnt/Seq-Summaries/2016/
 
 # The path, relative to the runfolder, where MiSeq analysis output is deposited
 ANALYSIS_PATH: ../MiSeqAnalysis/


### PR DESCRIPTION
- Only Unaligned is searched when looking for fastq files. Solves #123

- RunParameters  is loaded in GetMachineID, if not already done. This solves #124

-  Index is now read correctly from SampleSheet in cases where one index is masked. This solves #121
