### PR TITLE
No config wait + IndexCheck enhancements

### DIFF
--- a/lib/Molmed/Sisyphus/Common.pm
+++ b/lib/Molmed/Sisyphus/Common.pm
@@ -1684,12 +1684,9 @@ sub complete{
 
 sub readConfig{
     my $self = shift;
-    until(-e $self->PATH . '/sisyphus.yml'){
-	print STDERR "Waiting for config file " . $self->PATH . "/sisyphus.yml\n";
-	if(-e $self->PATH . '/sisyphus.yml.gz'){
-	    system('gunzip' , '-N',  $self->PATH . '/sisyphus.yml.gz');
-	}
-	sleep 5;
+    if(-e $self->PATH . '/sisyphus.yml.gz'){
+        system('gunzip' , '-N',  $self->PATH . '/sisyphus.yml.gz');
+        sleep 5;
     }
     my $conf = YAML::Tiny->read($self->PATH . '/sisyphus.yml') || confess "Failed to read '" . $self->PATH . "/sisyphus.yml'\n";
     return $conf->[0];

--- a/lib/Molmed/Sisyphus/IndexCheck.pm
+++ b/lib/Molmed/Sisyphus/IndexCheck.pm
@@ -10,14 +10,14 @@ our @EXPORT = qw(checkIndices);
 
 sub checkIndices{
 
-    my $sisyphus = $_[0];	
-    my $DemuxSumPath = $_[1];
-    my $noOfSamples = $_[2];
-    my $numLanes = $_[3];
-    my $debug = $_[4];
+	my $sisyphus = $_[0];	
+	my $DemuxSumPath = $_[1];
+	my $noOfSamples = $_[2];
+	my $numLanes = $_[3];
+	my $debug = $_[4];
 
-    my $failedIndexCheck = 0;
-    my $passedIndexCheck;
+	my $failedIndexCheck = 0;
+	my $passedIndexCheck;
 
 	# Read demuxSummary files for each lane, store info in hash
 	my %indexCount;
@@ -27,56 +27,56 @@ sub checkIndices{
 
 	foreach my $lane (1..$numLanes){
 
-	    $indexSection = 0;
-	    
-	    my (@counts, @indices1, @indices2);
+		$indexSection = 0;
+		
+		my (@counts, @indices1, @indices2);
 
-	    open (my $fh, "<", "$DemuxSumPath/$LanePrefix$lane.txt") or die "Can't open the file $DemuxSumPath/$LanePrefix$lane.txt: ";
+		open (my $fh, "<", "$DemuxSumPath/$LanePrefix$lane.txt") or die "Can't open the file $DemuxSumPath/$LanePrefix$lane.txt: ";
 
-	    while (my $line =<$fh>){
-		            
-		    chomp ($line);		
+		while (my $line =<$fh>){
+					
+			chomp ($line);		
 
-			    if ($line =~ /Index_Sequence/ || $indexSection ){           
-	     				
-				    $indexSection = 1;
+				if ($line =~ /Index_Sequence/ || $indexSection ){		   
+		 				
+					$indexSection = 1;
 			
 				# skip header	
-		        if ($line !~ /Index_Sequence/){
-		        
-		            my($index, $count) = split("\t", $line);
-		        
-				    my($index1, $index2) = split(/\Q+\E/, $index);
+				if ($line !~ /Index_Sequence/){
+				
+					my($index, $count) = split("\t", $line);
+				
+					my($index1, $index2) = split(/\Q+\E/, $index);
 
-		            push (@counts, $count);
-		            push (@indices1, $index1);
-				    
-		            if ($index2){
-					    push (@indices2, $index2);
-		            }
-		        }
-		    }
-	    }
+					push (@counts, $count);
+					push (@indices1, $index1);
+					
+					if ($index2){
+						push (@indices2, $index2);
+					}
+				}
+			}
+		}
 
-	    # Data is saved to hash
-	    $indexCount{$lane} = {'Indices' => { 'Index1' => \@indices1, 'Index2' => \@indices2 }, 'Counts' => \@counts};
-	    
+		# Data is saved to hash
+		$indexCount{$lane} = {'Indices' => { 'Index1' => \@indices1, 'Index2' => \@indices2 }, 'Counts' => \@counts};
+		
 	}
 
-    if ($debug){
+	if ($debug){
 
-        print "INDEXCOUNT HASH:\n";
-        print Dumper(\%indexCount);
-        print "SAMPLES PER LANE HASH:\n";
-        print Dumper($noOfSamples);
+		print "INDEXCOUNT HASH:\n";
+		print Dumper(\%indexCount);
+		print "SAMPLES PER LANE HASH:\n";
+		print Dumper($noOfSamples);
 
-    }    
+	}	
 
 	print "\nChecking indices...\n";
 
 	foreach my $lane (1..$numLanes){
 
-	    foreach my $indexRead (keys %{$indexCount{$lane}{'Indices'}}){
+		foreach my $indexRead (keys %{$indexCount{$lane}{'Indices'}}){
 
 			if (@{$indexCount{$lane}{'Indices'}{$indexRead}}){
 			
@@ -87,121 +87,121 @@ sub checkIndices{
 
 				if ($sigCount > 1){
 				
-				    print "\nThere are $sigCount significant undetermined index counts for Lane $lane $indexRead: \n";
+					print "\nThere are $sigCount significant undetermined index counts for Lane $lane $indexRead: \n";
 				
 				}
 				if ($sigCount == 1){
 				
-				    print "\nThere is $sigCount significant undetermined index count for Lane $lane $indexRead: \n";
+					print "\nThere is $sigCount significant undetermined index count for Lane $lane $indexRead: \n";
 
 				}
 
 				foreach my $unidentifiedIndex (@sigCounts){
 	
-                    $passedIndexCheck = 0;
+					$passedIndexCheck = 0;
 	
-				    foreach my $idxRead (keys %{$indexCount{$lane}{'Indices'}}){
+					foreach my $idxRead (keys %{$indexCount{$lane}{'Indices'}}){
 
-				        if (@{$noOfSamples->{$lane}->{'Indices'}->{$idxRead}}){
+						if (@{$noOfSamples->{$lane}->{'Indices'}->{$idxRead}}){
 
-				            @refIndices = @{$noOfSamples->{$lane}->{'Indices'}->{$idxRead}};
-				    
-				            if ( grep {$_ eq $unidentifiedIndex} @refIndices){
-				            
-				                if ($idxRead eq $indexRead){
-				        
-				                    print "Index $unidentifiedIndex is present in Samplesheet among $indexRead. OK!\n";
+							@refIndices = @{$noOfSamples->{$lane}->{'Indices'}->{$idxRead}};
+					
+							if ( grep {$_ eq $unidentifiedIndex} @refIndices){
+							
+								if ($idxRead eq $indexRead){
+						
+									print "Index $unidentifiedIndex is present in Samplesheet among $indexRead. OK!\n";
 				
-				                    $passedIndexCheck = 1;                     
-				        
-				                }
-				                else{
-				        
-				                    print "It appears that $unidentifiedIndex is present in Samplesheet among $idxRead.\n";
-				            
-				                }
+									$passedIndexCheck = 1;					 
+						
+								}
+								else{
+						
+									print "It appears that $unidentifiedIndex is present in Samplesheet among $idxRead.\n";
+							
+								}
 
-				            }
-				            elsif ( mismatch($unidentifiedIndex, \@refIndices) ){
+							}
+							elsif ( mismatch($unidentifiedIndex, \@refIndices) ){
 
-				                if ($idxRead eq $indexRead){
-				        
-				                    print "Index $unidentifiedIndex is one mismatch from being a correct index among $indexRead. OK!\n";
-				                    
-				                    $passedIndexCheck = 1;
+								if ($idxRead eq $indexRead){
+						
+									print "Index $unidentifiedIndex is one mismatch from being a correct index among $indexRead. OK!\n";
+									
+									$passedIndexCheck = 1;
 			  
-				                }
-				                else{
-				          
-				                    print "Index $unidentifiedIndex is one mismatch from being a correct index among $idxRead.\n";
-				                
-				                }
+								}
+								else{
+						  
+									print "Index $unidentifiedIndex is one mismatch from being a correct index among $idxRead.\n";
+								
+								}
 
-				            }
-				            elsif ($unidentifiedIndex =~ /N.*N/ ){
+							}
+							elsif ($unidentifiedIndex =~ /N.*N/ ){
 
-				                print "Index $unidentifiedIndex contains read errors. OK!\n";
+								print "Index $unidentifiedIndex contains read errors. OK!\n";
 
-				                $passedIndexCheck = 1; 
+								$passedIndexCheck = 1; 
 
-				            }
-				            elsif (grep {$_ eq reverse($unidentifiedIndex)} @refIndices){
+							}
+							elsif (grep {$_ eq reverse($unidentifiedIndex)} @refIndices){
 
-				                if ($idxRead eq $indexRead){
+								if ($idxRead eq $indexRead){
 
-				                    print "The reverse of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
-				                
-				                }
-				                else{
-				                
-				                    print "The reverse of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
+									print "The reverse of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
+								
+								}
+								else{
+								
+									print "The reverse of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
 
-				                }
+								}
 
-				            }
-				            elsif (grep {$_ eq reverseComplement($unidentifiedIndex, 1)} @refIndices){
+							}
+							elsif (grep {$_ eq reverseComplement($unidentifiedIndex, 1)} @refIndices){
 
-				                if ($idxRead eq $indexRead){
-				        
-				                    print "The complement of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
+								if ($idxRead eq $indexRead){
+						
+									print "The complement of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
 
-				                }
-				                else{
+								}
+								else{
 
-				                    print "The complement of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
+									print "The complement of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
 
-				                }
+								}
 
-				            }
-				            elsif (grep {$_ eq reverseComplement($unidentifiedIndex, 0)} @refIndices){
+							}
+							elsif (grep {$_ eq reverseComplement($unidentifiedIndex, 0)} @refIndices){
 
-				                if ($idxRead eq $indexRead){
+								if ($idxRead eq $indexRead){
 
-				                    print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
+									print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
 
-				                }
-				                else{
+								}
+								else{
 
-				                    print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
-				            
-				                }
-				            }
-				    
-				        }
-				    
-				    }
-				    unless ($passedIndexCheck){
+									print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
+							
+								}
+							}
+					
+						}
+					
+					}
+					unless ($passedIndexCheck){
 
-				        print "Please investigate index $unidentifiedIndex.\n";
+						print "Please investigate index $unidentifiedIndex.\n";
 
-				        $failedIndexCheck = 1; 
+						$failedIndexCheck = 1; 
 
-				    }
+					}
 			 
 				}
 
 			}
-	    }
+		}
 	}
 
 	return $failedIndexCheck;
@@ -209,90 +209,90 @@ sub checkIndices{
 
 sub significanceTest{
 
-    my @countArray = @{$_[0]};
-    my @indexArray = @{$_[1]};
-    my $lane = $_[2];
-    my $sisyphus = $_[3];
-    my $DemuxSumPath = $_[4];
-    
-    my $total = $sisyphus->getBarcodeCount($lane, $DemuxSumPath);
+	my @countArray = @{$_[0]};
+	my @indexArray = @{$_[1]};
+	my $lane = $_[2];
+	my $sisyphus = $_[3];
+	my $DemuxSumPath = $_[4];
+	
+	my $total = $sisyphus->getBarcodeCount($lane, $DemuxSumPath);
 
-    my @sigIndices;
+	my @sigIndices;
 
-    my $counter = 0;
+	my $counter = 0;
 
-    # Start with the first (and greatest) element
-    my $count = $countArray[$counter];
+	# Start with the first (and greatest) element
+	my $count = $countArray[$counter];
 
-    while ($count >= 0.01*$total){
+	while ($count >= 0.01*$total){
 
-        push ( @sigIndices, $indexArray[$counter] );
+		push ( @sigIndices, $indexArray[$counter] );
 
-        $counter++;
+		$counter++;
 
-        $count = $countArray[$counter];
-        
-    }
+		$count = $countArray[$counter];
+		
+	}
 
-    return @sigIndices;
+	return @sigIndices;
 
 }
 
 sub mismatch{
 
-    my $index = $_[0];
-    my @shIndices = @{$_[1]};
+	my $index = $_[0];
+	my @shIndices = @{$_[1]};
 
-    my @mismatchArray;
+	my @mismatchArray;
 
-    # Compare index with SampleSheet indices and count number of mismatches
-    for my $shIndex (@shIndices){
-        
-        my $noMismatches = 0;
-        
-        for(0 .. length($index)) {
-        
-            my $char = substr($shIndex, $_, 1);
-             
-                   if ($char ne substr($index, $_, 1)) {
-                
-                        $noMismatches++;
-                    } 
-        }
-        
-        push (@mismatchArray, $noMismatches);
-    }
+	# Compare index with SampleSheet indices and count number of mismatches
+	for my $shIndex (@shIndices){
+		
+		my $noMismatches = 0;
+		
+		for(0 .. length($index)) {
+		
+			my $char = substr($shIndex, $_, 1);
+			 
+				   if ($char ne substr($index, $_, 1)) {
+				
+						$noMismatches++;
+					} 
+		}
+		
+		push (@mismatchArray, $noMismatches);
+	}
 
-    #Check if index is one mismatch from a real index
-    if (grep {$_ == 1} @mismatchArray){
+	#Check if index is one mismatch from a real index
+	if (grep {$_ == 1} @mismatchArray){
 
-        return 1;
-    }
+		return 1;
+	}
 
-    else {
+	else {
 
-        return 0;
-    
-    }
+		return 0;
+	
+	}
 
 }
 
 sub reverseComplement{
 
-    my $tag = $_[0];
-    my $justComp = $_[1];
-    
-    my $revComp = $tag;
+	my $tag = $_[0];
+	my $justComp = $_[1];
+	
+	my $revComp = $tag;
  
-    unless($justComp){
-        # Reverse index/tag 
-        $revComp = reverse $tag;
-    }
+	unless($justComp){
+		# Reverse index/tag 
+		$revComp = reverse $tag;
+	}
 
-    # Complement index/tag
-    $revComp =~ tr/ACGTacgt/TGCAtgca/;
+	# Complement index/tag
+	$revComp =~ tr/ACGTacgt/TGCAtgca/;
  
-    return $revComp;
+	return $revComp;
 
 }
 

--- a/lib/Molmed/Sisyphus/IndexCheck.pm
+++ b/lib/Molmed/Sisyphus/IndexCheck.pm
@@ -96,13 +96,11 @@ sub checkIndices{
 
 				}
 
-				$passedIndexCheck = 0;        
-
 				foreach my $unidentifiedIndex (@sigCounts){
-		
+	
+                    $passedIndexCheck = 0;
+	
 				    foreach my $idxRead (keys %{$indexCount{$lane}{'Indices'}}){
-
-                        my $test = $noOfSamples->{$lane}->{'Indices'}->{$idxRead};
 
 				        if (@{$noOfSamples->{$lane}->{'Indices'}->{$idxRead}}){
 
@@ -119,7 +117,7 @@ sub checkIndices{
 				                }
 				                else{
 				        
-				                    print "It appears that $unidentifiedIndex is present in Samplesheet among $idxRead. ";
+				                    print "It appears that $unidentifiedIndex is present in Samplesheet among $idxRead.\n";
 				            
 				                }
 
@@ -135,12 +133,12 @@ sub checkIndices{
 				                }
 				                else{
 				          
-				                    print "Index $unidentifiedIndex is one mismatch from being a correct index among $idxRead. ";
+				                    print "Index $unidentifiedIndex is one mismatch from being a correct index among $idxRead.\n";
 				                
 				                }
 
 				            }
-				            elsif ($unidentifiedIndex =~ /N\.*N/ ){
+				            elsif ($unidentifiedIndex =~ /N.*N/ ){
 
 				                print "Index $unidentifiedIndex contains read errors. OK!\n";
 
@@ -151,12 +149,12 @@ sub checkIndices{
 
 				                if ($idxRead eq $indexRead){
 
-				                    print "The reverse of index $unidentifiedIndex is present in SampleSheet among $indexRead. ";
+				                    print "The reverse of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
 				                
 				                }
 				                else{
 				                
-				                    print "The reverse of index $unidentifiedIndex is present in SampleSheet among $idxRead. ";
+				                    print "The reverse of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
 
 				                }
 
@@ -165,12 +163,12 @@ sub checkIndices{
 
 				                if ($idxRead eq $indexRead){
 				        
-				                    print "The complement of index $unidentifiedIndex is present in SampleSheet among $indexRead. ";
+				                    print "The complement of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
 
 				                }
 				                else{
 
-				                    print "The complement of index $unidentifiedIndex is present in SampleSheet among $idxRead. ";
+				                    print "The complement of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
 
 				                }
 
@@ -179,12 +177,12 @@ sub checkIndices{
 
 				                if ($idxRead eq $indexRead){
 
-				                    print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $indexRead. ";
+				                    print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $indexRead.\n";
 
 				                }
 				                else{
 
-				                    print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $idxRead. ";
+				                    print "The reverse complement of index $unidentifiedIndex is present in SampleSheet among $idxRead.\n";
 				            
 				                }
 				            }
@@ -194,9 +192,9 @@ sub checkIndices{
 				    }
 				    unless ($passedIndexCheck){
 
-				    print "Please investigate index $unidentifiedIndex.\n";
+				        print "Please investigate index $unidentifiedIndex.\n";
 
-				    $failedIndexCheck = 1; 
+				        $failedIndexCheck = 1; 
 
 				    }
 			 

--- a/sisyphus.pl
+++ b/sisyphus.pl
@@ -432,7 +432,6 @@ $config->{BCL2FASTQ} --input-dir '$rfPath/Data/Intensities/BaseCalls' --output-d
 check_errs \$? "bcl2fastq failed in $fastqPath/IndexCheck"
 
 checkIndices.pl -runfolder '$rfPath' -demuxSummary '$rfPath/IndexCheck/Stats' 
-check_errs \$? "IndexCheck failed"
 
 EOF
 
@@ -457,7 +456,6 @@ unless($preIndexCheck){
 
 print $scriptFh <<EOF
 checkIndices.pl -runfolder '$rfPath'
-check_errs \$? "IndexCheck failed"
 
 EOF
 }

--- a/sisyphus.pl
+++ b/sisyphus.pl
@@ -432,6 +432,8 @@ $config->{BCL2FASTQ} --input-dir '$rfPath/Data/Intensities/BaseCalls' --output-d
 check_errs \$? "bcl2fastq failed in $fastqPath/IndexCheck"
 
 checkIndices.pl -runfolder '$rfPath' -demuxSummary '$rfPath/IndexCheck/Stats' 
+check_errs \$? "IndexCheck FAILED"
+
 
 EOF
 
@@ -456,6 +458,9 @@ unless($preIndexCheck){
 
 print $scriptFh <<EOF
 checkIndices.pl -runfolder '$rfPath'
+
+# Save return value for later use
+INDEXCHECK_RETURN_VAL=\$?
 
 EOF
 }
@@ -532,6 +537,12 @@ check_errs \$? "FAILED QC"
 EOF
 }
 }
+
+print $scriptFh <<EOF;
+
+# Now check if indexCheck was successful
+check_errs \$INDEXCHECK_RETURN_VAL "IndexCheck FAILED"
+EOF
 
 unless($noUppmaxProcessing) {
 print $scriptFh <<EOF;

--- a/t/miseq_qc/sisyphus.yml
+++ b/t/miseq_qc/sisyphus.yml
@@ -11,19 +11,13 @@ SENDER: seq@medsci.uu.se
 CASAVA: /opt/CASAVA/1.8.4/bin/
 
 #Path to bcl2fastq binaries
-BCL2FASTQ: /usr/local/bin/bcl2fastq-v2.16.0.10
+BCL2FASTQ: /usr/local/bin/bcl2fastq-v2.17.1.14
 
-# Demultiplex mismatches, set to 1 or 0 for each lane individually
-# Default is to allow one mismatch in all lanes
+# Demultiplex mismatches, set to 1 or 0 for each index read individually
+# Default is to allow one mismatch in all index reads
 MISMATCH:
         1: 1
         2: 1
-        3: 1
-        4: 1
-        5: 1
-        6: 1
-        7: 1
-        8: 1
 
 MACHINES:
         D00457:
@@ -79,7 +73,17 @@ NGI_REMOTE_PATH: /proj/a2015179/archive/
 NGI_PROJECT: a2015179
 
 # Change to 1 to process with NGI-pipeline
-NGI_PROCESSING: 0 
+NGI_PROCESSING: 0
+
+# Change to 1 to perform indeck check before demultiplexing
+PRE_DEMULTIPLEX_INDEX_CHECK: 0 
+
+# Change to 1 to ignore missing fastqs
+IGNORE_MISSING_FASTQS: 0
+
+# Change to 0 to not use ssverify.sh for archive verification and instead use 
+# sisyphus own verfication procedure 
+USE_SSVERIFY: 1
 
 # The host on which to archive the runfolder
 ARCHIVE_HOST: milou-b.uppmax.uu.se
@@ -102,7 +106,7 @@ TEMP_PATH: /proj/a2009002/private/nobackup/tmp
 SUMMARY_HOST: mm-xlas002
 
 # The directory on ARCHIVE_HOST to put the runfolder in
-SUMMARY_PATH: /mnt/Seq-Summaries/2015/
+SUMMARY_PATH: /mnt/Seq-Summaries/2016/
 
 # The path, relative to the runfolder, where MiSeq analysis output is deposited
 ANALYSIS_PATH: ../MiSeqAnalysis/


### PR DESCRIPTION
- Sisyphus no longer waits for config file
-  Made changes to IndexCheck:
 - Modified prints
 - Fixed regex 
 - Failing indexcheck will no longer terminate sisyphus.sh. I realised that I often want to look at the quickReport even if something is found among Undetermined indices. 
- Updated test config 

**NB: For code reviewing, I suggest looking at the two first commits.**