### PR TITLE
More resources given to slurmjobs

### DIFF
--- a/aeacus-reports.pl
+++ b/aeacus-reports.pl
@@ -169,17 +169,17 @@ foreach my $proj (keys %{$sampleSheet}){
     # Create a slurm job handler
     my $projJob =
       Molmed::Sisyphus::Uppmax::SlurmJob->new(
-					       DEBUG=>$debug,         # bool
-					       SCRIPTDIR=>$scriptDir, # Directory for writing the script
-					       EXECDIR=>$rfPath,      # Directory from which to run the script
-					       NAME=>"$proj-$rfShort",# Name of job, also used in script name
-					       PROJECT=>$uProj,       # project for resource allocation
-					       TIME=>"0-15:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
-					       QOS=>$uQos,            # High priority
-					       PARTITION=>'core',      # core or node (or devel));
-                           CORES=>'2',
-                 MAIL_USER=>$email,
-                 MAIL_TYPE=>'FAIL'
+                            DEBUG=>$debug,         # bool
+                            SCRIPTDIR=>$scriptDir, # Directory for writing the script
+                            EXECDIR=>$rfPath,      # Directory from which to run the script
+                            NAME=>"$proj-$rfShort",# Name of job, also used in script name
+                            PROJECT=>$uProj,       # project for resource allocation
+                            TIME=>"0-15:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
+                            QOS=>$uQos,            # High priority
+                            PARTITION=>'core',      # core or node (or devel));
+                            CORES=>'2',
+                            MAIL_USER=>$email,
+                            MAIL_TYPE=>'FAIL'
 					      );
     foreach my $lane (keys (%{$sampleSheet->{$proj}})){
 	$projJob->addDep($ffJobs{$lane}) if exists($ffJobs{$lane});

--- a/aeacus-reports.pl
+++ b/aeacus-reports.pl
@@ -174,9 +174,10 @@ foreach my $proj (keys %{$sampleSheet}){
 					       EXECDIR=>$rfPath,      # Directory from which to run the script
 					       NAME=>"$proj-$rfShort",# Name of job, also used in script name
 					       PROJECT=>$uProj,       # project for resource allocation
-					       TIME=>"0-06:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
+					       TIME=>"0-15:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
 					       QOS=>$uQos,            # High priority
 					       PARTITION=>'core',      # core or node (or devel));
+                           CORES=>'2',
                  MAIL_USER=>$email,
                  MAIL_TYPE=>'FAIL'
 					      );
@@ -214,10 +215,10 @@ my $repJob =
                                            EXECDIR=>$rfPath,      # Directory from which to run the script
                                            NAME=>"Rep-$rfShort", # Name of job, also used in script name
                                            PROJECT=>$uProj,       # project for resource allocation
-                                           TIME=>"0-10:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
+                                           TIME=>"0-20:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
                                            QOS=>$uQos,            # High priority
                                            PARTITION=>'core',     # core or node (or devel));
-                                           CORES=>'2',
+                                           CORES=>'4',
                                            MAIL_USER=>$email,
                                            MAIL_TYPE=>'FAIL'
                                           );


### PR DESCRIPTION
I have noticed that Proj and Rep jobs fail quite often lately. This happens to HiSeqX runs with quite a lot of samples (~ 20 per lane). 