### PR TITLE
Fix PDL bug

### DIFF
--- a/lib/Molmed/Sisyphus/QStat.pm
+++ b/lib/Molmed/Sisyphus/QStat.pm
@@ -9,6 +9,7 @@ use Archive::Zip qw( :ERROR_CODES :CONSTANTS );
 use File::Basename;
 use Molmed::Sisyphus::Common qw(mkpath);
 use Storable 'dclone';
+$PDL::toolongtoprint = 10000000;
 
 our $AUTOLOAD;
 

--- a/lib/Molmed/Sisyphus/QStat.pm
+++ b/lib/Molmed/Sisyphus/QStat.pm
@@ -1459,47 +1459,4 @@ sub loadData{
     return 1;
 }
 
-# 500 cycles is too much for dumping the QHIST matrix with standard PDL
-# Override the original string function
-
-
-package PDL::Core;
-
-my $max_elem = 10000000;  # set your max here
-
-{
-no warnings 'redefine';
-sub PDL::Core::string {
-   my ( $self, $format ) = @_;
-   if ( $PDL::_STRINGIZING ) {
-      return "ALREADY_STRINGIZING_NO_LOOPS";
-   }
-   local $PDL::_STRINGIZING = 1;
-   my $ndims = $self->getndims;
-   if ( $self->nelem > $max_elem ) {
-      return "TOO LONG TO PRINT";
-   }
-   if ( $ndims == 0 ) {
-      if ( $self->badflag() and $self->isbad() ) {
-         return "BAD";
-      }
-      else {
-         my @x = $self->at();
-         return ( $format ? sprintf( $format, $x[ 0 ] ) : "$x[0]" );
-      }
-   }
-   return "Null"  if $self->isnull;
-   return "Empty" if $self->isempty;    # Empty piddle
-
-   local $PDL::Core::sep  = $PDL::use_commas ? "," : " ";
-   local $PDL::Core::sep2 = $PDL::use_commas ? "," : "";
-   if ( $ndims == 1 ) {
-      return PDL::Core::str1D( $self, $format );
-   }
-   else {
-      return PDL::Core::strND( $self, $format, 0 );
-   }
-}
-}
-
 1;


### PR DESCRIPTION
PDL variable *toolongtoprint* is now set to 10000000. It seems like the previous solution of overriding the string function in PDL is no longer working with PDL v2.017.

This branch has been tested on Irma. 