### PR TITLE
Disabled mail notifications about Arch jobs

### DIFF
--- a/aeacus-reports.pl
+++ b/aeacus-reports.pl
@@ -256,7 +256,7 @@ my $archJob =
 					   PARTITION=>'core',      # core or node (or devel))
 					   CORES=>'2',
              MAIL_USER=>$email,
-             MAIL_TYPE=>'FAIL'
+             MAIL_TYPE=>'NONE'
 					  );
 $archJob->addDep($repJob);
 $archJob->addCommand("module load uppmax");


### PR DESCRIPTION
The Arch job tries to load the SweStore module on Irma, which is not installed, and terminates with error. This small fix makes sure that we do not get an e-mail every time that happens. 

Tested on Irma. 