### PR TITLE
Gnuplot hotfix

### DIFF
--- a/aeacus-reports.pl
+++ b/aeacus-reports.pl
@@ -226,7 +226,7 @@ foreach my $job (values %projJobs){
     $repJob->addDep($job);
 }
 $repJob->addCommand("module load uppmax");
-$repJob->addCommand("module load gnuplot");
+$repJob->addCommand("module load gnuplot/system");
 $repJob->addCommand("umask 007");
 $repJob->addCommand("$FindBin::Bin/generateReport.pl -runfolder $rfPath $debugFlag", "generateReport.pl on $rfPath FAILED");
 print STDERR "Submitting Rep-$rfShort\t";


### PR DESCRIPTION
After a recent maintenance on Uppmax, loading gnuplot via the module system will now result in a > v.5 version of the software. We do however need v.4 for our plots to get the correct color. 

Version 4 of gnuplot is now loaded in Rep*.sh 