### PR TITLE
Now the correct gnuplot version is loaded for project reports

### DIFF
--- a/aeacus-reports.pl
+++ b/aeacus-reports.pl
@@ -185,7 +185,7 @@ foreach my $proj (keys %{$sampleSheet}){
 	$projJob->addDep($ffJobs{$lane}) if exists($ffJobs{$lane});
     }
     $projJob->addCommand("module load uppmax");
-    $projJob->addCommand("module load gnuplot");
+    $projJob->addCommand("module load gnuplot/system");
     $projJob->addCommand("umask 007");
     my $cmd = "$FindBin::Bin/extractProject.pl -runfolder $rfPath -project '$proj' -outdir '$oPath/$proj' $debugFlag";
     foreach my $lane (@{$skipLanes}){


### PR DESCRIPTION
Unfortunately the last hotfix only fixed the issue for the summaryReport, project reports (that are sent to users) were still purple. With the changes in this PR, the correct version of gnuplot will be loaded for the extractProject jobs too. 