### PR TITLE
Extended amount of cores för aeacus-stats.pl

### DIFF
--- a/aeacus-stats.pl
+++ b/aeacus-stats.pl
@@ -157,8 +157,9 @@ for(my $i=1; $i<=$numLanes; $i++){
 					      TIME=>"1-00:00:00",    # Maximum runtime, formatted as d-hh:mm:ss
 					      QOS=>$uQos,            # High priority
 					      PARTITION=>'core',     # core or node (or devel));
-                MAIL_USER=>$email,
-                MAIL_TYPE=>'FAIL'
+                                              CORES=>'4',            # number of cores
+                                              MAIL_USER=>$email,
+                                              MAIL_TYPE=>'FAIL'
 					     );
     $ffJob->addCommand("$FindBin::Bin/fastqStats.pl -runfolder $rfPath -lane $i $debugFlag", "fastqStats.pl on lane $i FAILED");
     $ffJobs{$i} = $ffJob;


### PR DESCRIPTION
FF-jobs terminated with a non-zero exit code due to memory limit hit. Aeacus-stats.pl updated with more cores. 