### PR TITLE
Skip index fastqs in aeacus scripts

### DIFF
--- a/extractProject.pl
+++ b/extractProject.pl
@@ -179,7 +179,11 @@ foreach my $sampleDir (readdir($pDirFh)){
     foreach my $fastq (grep /fastq.gz$/, readdir($seqDirFh)){
         if($fastq =~ m/L00(\d)_R\d_001.fastq/){
             next if($skipLanes{$1});
-        }else{
+        }elsif($fastq =~ m/L00(\d)_I\d_001.fastq/){
+            print "Skipping index fastq: $fastq\n" if($debug);
+            next;
+        }
+        else{
             die "Failed to extract lane from fastq name '$fastq'";
         }
         mkpath("$outDir/$sampleDir/",2770) unless(-e "$outDir/$sampleDir/");

--- a/fastqStats.pl
+++ b/fastqStats.pl
@@ -269,13 +269,14 @@ sub findFastq{
     my $files = shift;
     my $lanes = shift;
     my $file = $_;
-    if($file =~ m/\.fastq(\.gz)?$/){
+    # Only match read fastqs
+    if($file =~ m/R\d_001\.fastq(\.gz)?$/){
         foreach my $l (@{$lanes}){
             if($file =~ m/.+\/(.+)_\w+_L00${l}_/){
                 my @path = split '/', $file;
                 my $shiftIndex = $path[-3] eq 'Unaligned' ?  1 : $path[-2] eq 'Unaligned' ? 2 : 0;
                 my $sample = $1;
-		my $project = $shiftIndex != 2 ? $path[-3 + $shiftIndex] : $sample eq 'Undetermined' ? 'Undetermined_indices' : $sample;
+                my $project = $shiftIndex != 2 ? $path[-3 + $shiftIndex] : $sample eq 'Undetermined' ? 'Undetermined_indices' : $sample;
                 push @{$files{$project}->{$sample}}, $_;
             }
         }


### PR DESCRIPTION
Small update to make sure we can continue to produce aeacus reports when we start producing index fastqs for all kind of runs.

Testing carried out: 
- Run bcl2fastq with `--create-fastq-for-index-reads`
- Manual execution of fastqStats.pl, extractProject.pl and genereateReport.pl, in that order. 

Suprisingly, this also works when SampleIDs in samplesheet do not have the `Sample_` prefix. That is a good thing, since we probably will stop adding the prefix when discontinuing Hermes. 